### PR TITLE
Implement basic navigation and saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a lightweight prototype of the **Sermon Companion** app
 - **Scripture Integration** – Outlines can include Bible verses from your preferred translation.
 - **Customization** – Edit generated content in a simple text editor page and save it.
 - **Community Sharing** – Placeholder page for viewing sermons shared by other users.
+- **Local Saving** – Edited sermons are stored in your browser's local storage.
 
 The project does not include a full Angular build system due to environment limitations, but demonstrates the structure and key screens of the proposed app.
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,10 +7,46 @@ export class AppComponent extends HTMLElement {
             <ion-title>Sermon Companion</ion-title>
           </ion-toolbar>
         </ion-header>
-        <ion-content>
-          <home-page></home-page>
-        </ion-content>
+        <ion-content id="container"></ion-content>
       </ion-app>
     `;
+    this.container = this.querySelector('#container') as HTMLElement;
+    this.loadHome();
+  }
+
+  private container!: HTMLElement;
+
+  private loadHome() {
+    const home = document.createElement('home-page');
+    home.addEventListener('generated', (e: Event) => {
+      const outline = (e as CustomEvent<string>).detail;
+      this.loadEditor(outline);
+    });
+    home.addEventListener('open-community', () => this.loadCommunity());
+    this.container.innerHTML = '';
+    this.container.appendChild(home);
+  }
+
+  private loadEditor(content: string) {
+    const editor = document.createElement('editor-page') as any;
+    (editor as any).content = content;
+    editor.addEventListener('save', (e: Event) => {
+      const text = (e as CustomEvent<string>).detail;
+      try {
+        localStorage.setItem('sermon', text);
+      } catch {}
+      alert('Sermon saved');
+      this.loadHome();
+    });
+    editor.addEventListener('back', () => this.loadHome());
+    this.container.innerHTML = '';
+    this.container.appendChild(editor);
+  }
+
+  private loadCommunity() {
+    const community = document.createElement('community-page');
+    community.addEventListener('back', () => this.loadHome());
+    this.container.innerHTML = '';
+    this.container.appendChild(community);
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,9 @@
   <meta charset="utf-8">
   <title>Sermon Companion</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@ionic/core/css/ionic.bundle.css" />
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@ionic/core/dist/ionic/ionic.js"></script>
 </head>
 <body>
   <app-root></app-root>

--- a/src/pages/community/community.page.ts
+++ b/src/pages/community/community.page.ts
@@ -4,7 +4,7 @@ export class CommunityPage extends HTMLElement {
       <ion-header>
         <ion-toolbar>
           <ion-buttons slot="start">
-            <ion-back-button default-href="/"></ion-back-button>
+            <ion-button id="back">Back</ion-button>
           </ion-buttons>
           <ion-title>Community</ion-title>
         </ion-toolbar>
@@ -13,6 +13,9 @@ export class CommunityPage extends HTMLElement {
         <p>Shared sermons will appear here.</p>
       </ion-content>
     `;
+    this.querySelector('#back')?.addEventListener('click', () => {
+      this.dispatchEvent(new Event('back'));
+    });
   }
 }
 

--- a/src/pages/editor/editor.page.ts
+++ b/src/pages/editor/editor.page.ts
@@ -4,7 +4,7 @@ export class EditorPage extends HTMLElement {
       <ion-header>
         <ion-toolbar>
           <ion-buttons slot="start">
-            <ion-back-button default-href="/"></ion-back-button>
+            <ion-button id="back">Back</ion-button>
           </ion-buttons>
           <ion-title>Edit Sermon</ion-title>
         </ion-toolbar>
@@ -17,6 +17,9 @@ export class EditorPage extends HTMLElement {
     this.querySelector('#save')?.addEventListener('click', () => {
       const text = (this.querySelector('#editor') as HTMLTextAreaElement).value;
       this.dispatchEvent(new CustomEvent('save', { detail: text }));
+    });
+    this.querySelector('#back')?.addEventListener('click', () => {
+      this.dispatchEvent(new Event('back'));
     });
   }
 }

--- a/src/pages/home/home.page.ts
+++ b/src/pages/home/home.page.ts
@@ -20,9 +20,13 @@ export class HomePage extends HTMLElement {
           <ion-button expand="full" type="submit">Generate</ion-button>
         </form>
         <div id="result"></div>
+        <ion-button expand="full" id="community">Community</ion-button>
       </ion-content>
     `;
     this.querySelector('form')?.addEventListener('submit', this.onSubmit.bind(this));
+    this.querySelector('#community')?.addEventListener('click', () => {
+      this.dispatchEvent(new Event('open-community'));
+    });
   }
 
   async onSubmit(e: Event) {
@@ -36,6 +40,9 @@ export class HomePage extends HTMLElement {
     });
     const result = await response.json();
     (this.querySelector('#result') as HTMLElement).innerText = result.outline || 'Error generating outline';
+    if (result.outline) {
+      this.dispatchEvent(new CustomEvent('generated', { detail: result.outline }));
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add CDN scripts for Ionic components
- enable simple routing in `AppComponent`
- dispatch events for page transitions
- add back buttons to Editor and Community pages
- allow saving generated sermons to local storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847998500048327aac1a6499cb32a6e