### PR TITLE
Add sermon pages with separated templates

### DIFF
--- a/features/sermon/create/create-sermon.page.css
+++ b/features/sermon/create/create-sermon.page.css
@@ -1,0 +1,1 @@
+/* Styles for create sermon page */

--- a/features/sermon/create/create-sermon.page.html
+++ b/features/sermon/create/create-sermon.page.html
@@ -1,0 +1,20 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Create Sermon</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <form (ngSubmit)="generate()" #form="ngForm">
+    <ion-item>
+      <ion-label position="stacked">Theme or Scripture</ion-label>
+      <ion-input name="theme" required [(ngModel)]="theme"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Length (minutes)</ion-label>
+      <ion-input type="number" name="length" required min="1" [(ngModel)]="length"></ion-input>
+    </ion-item>
+    <ion-button expand="full" type="submit" [disabled]="form.invalid">Generate</ion-button>
+  </form>
+
+  <app-sermon-editor *ngIf="generated" [content]="generated" (save)="save($event)" (back)="cancel()"></app-sermon-editor>
+</ion-content>

--- a/features/sermon/create/create-sermon.page.ts
+++ b/features/sermon/create/create-sermon.page.ts
@@ -1,2 +1,45 @@
-export class CreateSermonPage extends HTMLElement {}
-customElements.define('create-sermon-page', CreateSermonPage);
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { SermonAIService } from '../../../core/services/sermon-ai.service';
+import { StorageService } from '../../../core/services/storage.service';
+import { SermonEditorComponent } from '../editor/sermon-editor.component';
+
+export interface Sermon {
+  id: number;
+  title: string;
+  content: string;
+}
+
+@Component({
+  selector: 'app-create-sermon',
+  standalone: true,
+  imports: [IonicModule, FormsModule, SermonEditorComponent],
+  templateUrl: './create-sermon.page.html',
+  styleUrls: ['./create-sermon.page.css']
+})
+export class CreateSermonPage {
+  theme = '';
+  length = 5;
+  generated = '';
+
+  constructor(private ai: SermonAIService, private storage: StorageService) {}
+
+  async generate() {
+    this.generated = await this.ai.generateOutline({ theme: this.theme, length: this.length });
+  }
+
+  save(content: string) {
+    const sermons = this.storage.get<Sermon[]>('sermons') || [];
+    sermons.push({ id: Date.now(), title: this.theme || 'Untitled', content });
+    this.storage.set('sermons', sermons);
+    this.generated = '';
+    this.theme = '';
+    this.length = 5;
+    alert('Sermon saved');
+  }
+
+  cancel() {
+    this.generated = '';
+  }
+}

--- a/features/sermon/detail/sermon-detail.page.css
+++ b/features/sermon/detail/sermon-detail.page.css
@@ -1,0 +1,3 @@
+pre {
+  white-space: pre-wrap;
+}

--- a/features/sermon/detail/sermon-detail.page.html
+++ b/features/sermon/detail/sermon-detail.page.html
@@ -1,0 +1,11 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button (click)="back.emit()">Back</ion-button>
+    </ion-buttons>
+    <ion-title>{{ sermon?.title }}</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <pre>{{ sermon?.content }}</pre>
+</ion-content>

--- a/features/sermon/detail/sermon-detail.page.ts
+++ b/features/sermon/detail/sermon-detail.page.ts
@@ -1,2 +1,21 @@
-export class SermonDetailPage extends HTMLElement {}
-customElements.define('sermon-detail-page', SermonDetailPage);
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule } from '@angular/common';
+
+export interface SermonDetail {
+  id: number;
+  title: string;
+  content: string;
+}
+
+@Component({
+  selector: 'app-sermon-detail',
+  standalone: true,
+  imports: [IonicModule, CommonModule],
+  templateUrl: './sermon-detail.page.html',
+  styleUrls: ['./sermon-detail.page.css']
+})
+export class SermonDetailPage {
+  @Input() sermon?: SermonDetail;
+  @Output() back = new EventEmitter<void>();
+}

--- a/features/sermon/editor/sermon-editor.component.css
+++ b/features/sermon/editor/sermon-editor.component.css
@@ -1,0 +1,3 @@
+.editor-area {
+  height: 60vh;
+}

--- a/features/sermon/editor/sermon-editor.component.html
+++ b/features/sermon/editor/sermon-editor.component.html
@@ -1,0 +1,12 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button (click)="back.emit()">Back</ion-button>
+    </ion-buttons>
+    <ion-title>Edit Sermon</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content>
+  <ion-textarea [(ngModel)]="content" class="editor-area"></ion-textarea>
+  <ion-button expand="full" (click)="save.emit(content)">Save</ion-button>
+</ion-content>

--- a/features/sermon/editor/sermon-editor.component.ts
+++ b/features/sermon/editor/sermon-editor.component.ts
@@ -6,20 +6,8 @@ import { IonicModule } from '@ionic/angular';
   selector: 'app-sermon-editor',
   standalone: true,
   imports: [IonicModule, FormsModule],
-  template: `
-    <ion-header>
-      <ion-toolbar>
-        <ion-buttons slot="start">
-          <ion-button (click)="back.emit()">Back</ion-button>
-        </ion-buttons>
-        <ion-title>Edit Sermon</ion-title>
-      </ion-toolbar>
-    </ion-header>
-    <ion-content>
-      <ion-textarea [(ngModel)]="content" style="height: 60vh"></ion-textarea>
-      <ion-button expand="full" (click)="save.emit(content)">Save</ion-button>
-    </ion-content>
-  `
+  templateUrl: './sermon-editor.component.html',
+  styleUrls: ['./sermon-editor.component.css']
 })
 export class SermonEditorComponent {
   @Input() content = '';

--- a/features/sermon/list/sermon-list.page.css
+++ b/features/sermon/list/sermon-list.page.css
@@ -1,0 +1,1 @@
+/* styles for sermon list */

--- a/features/sermon/list/sermon-list.page.html
+++ b/features/sermon/list/sermon-list.page.html
@@ -1,0 +1,13 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>My Sermons</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content>
+  <ion-list>
+    <ion-item *ngFor="let s of sermons" (click)="select.emit(s)">
+      {{ s.title }}
+    </ion-item>
+    <ion-item *ngIf="!sermons.length">No saved sermons</ion-item>
+  </ion-list>
+</ion-content>

--- a/features/sermon/list/sermon-list.page.ts
+++ b/features/sermon/list/sermon-list.page.ts
@@ -1,2 +1,25 @@
-export class SermonListPage extends HTMLElement {}
-customElements.define('sermon-list-page', SermonListPage);
+import { Component, EventEmitter, Output } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule } from '@angular/common';
+import { StorageService } from '../../../core/services/storage.service';
+import { Sermon } from '../create/create-sermon.page';
+
+@Component({
+  selector: 'app-sermon-list',
+  standalone: true,
+  imports: [IonicModule, CommonModule],
+  templateUrl: './sermon-list.page.html',
+  styleUrls: ['./sermon-list.page.css']
+})
+export class SermonListPage {
+  sermons: Sermon[] = [];
+  @Output() select = new EventEmitter<Sermon>();
+
+  constructor(private storage: StorageService) {
+    this.load();
+  }
+
+  load() {
+    this.sermons = this.storage.get<Sermon[]>('sermons') || [];
+  }
+}


### PR DESCRIPTION
## Summary
- implement CreateSermonPage, SermonDetailPage and SermonListPage
- move SermonEditorComponent markup to external template and css
- provide HTML and CSS files for all sermon components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a56ac12883279e666d7ef017c06d