### PR TITLE
Implement reflection page with separated HTML and CSS

### DIFF
--- a/features/reflection/reflection.page.css
+++ b/features/reflection/reflection.page.css
@@ -1,0 +1,1 @@
+/* Styles for reflection page */

--- a/features/reflection/reflection.page.html
+++ b/features/reflection/reflection.page.html
@@ -1,0 +1,17 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Reflection</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-textarea [(ngModel)]="text" placeholder="Write your reflection"></ion-textarea>
+  <ion-button expand="full" (click)="save()">Save</ion-button>
+
+  <ion-list>
+    <ion-item *ngFor="let r of reflections">
+      {{ r.text }}
+    </ion-item>
+    <ion-item *ngIf="!reflections.length">No reflections yet</ion-item>
+  </ion-list>
+</ion-content>

--- a/features/reflection/reflection.page.ts
+++ b/features/reflection/reflection.page.ts
@@ -1,2 +1,37 @@
-export class ReflectionPage extends HTMLElement {}
-customElements.define('reflection-page', ReflectionPage);
+import { Component } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { StorageService } from '../../core/services/storage.service';
+
+export interface Reflection {
+  id: number;
+  text: string;
+}
+
+@Component({
+  selector: 'app-reflection',
+  standalone: true,
+  imports: [IonicModule, FormsModule, CommonModule],
+  templateUrl: './reflection.page.html',
+  styleUrls: ['./reflection.page.css']
+})
+export class ReflectionPage {
+  text = '';
+  reflections: Reflection[] = [];
+
+  constructor(private storage: StorageService) {
+    this.load();
+  }
+
+  load() {
+    this.reflections = this.storage.get<Reflection[]>('reflections') || [];
+  }
+
+  save() {
+    const r: Reflection = { id: Date.now(), text: this.text };
+    this.reflections.push(r);
+    this.storage.set('reflections', this.reflections);
+    this.text = '';
+  }
+}


### PR DESCRIPTION
## Summary
- add standalone Angular page for reflection notes
- separate template and styles into `reflection.page.html` and `reflection.page.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847a73382a88327856aa59fd78801fe