### PR TITLE
Add unit test for sermon creation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.spec.ts']
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "scripts": {
     "start": "echo 'No build system available'",
-    "test": "echo 'No tests specified'"
+    "test": "jest"
   },
   "dependencies": {
     "@ionic/core": "^7.4.0",
@@ -14,5 +14,11 @@
     "@angular/forms": "^17.0.0",
     "rxjs": "^7.8.0",
     "zone.js": "^0.13.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.3",
+    "jest": "^29.6.4",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.3.3"
   }
 }

--- a/tests/create-sermon.page.spec.ts
+++ b/tests/create-sermon.page.spec.ts
@@ -1,0 +1,35 @@
+import { CreateSermonPage } from '../features/sermon/create/create-sermon.page';
+import { SermonAIService } from '../core/services/sermon-ai.service';
+import { StorageService } from '../core/services/storage.service';
+
+// Simple jest-based unit test covering the main flow of UC-SERMON-001
+
+describe('CreateSermonPage', () => {
+  let ai: jest.Mocked<SermonAIService>;
+  let storage: jest.Mocked<StorageService>;
+  let page: CreateSermonPage;
+
+  beforeEach(() => {
+    ai = { generateOutline: jest.fn() } as any;
+    storage = { get: jest.fn(), set: jest.fn() } as any;
+    page = new CreateSermonPage(ai, storage);
+  });
+
+  it('generates a sermon outline from theme and length', async () => {
+    ai.generateOutline.mockResolvedValue('Outline');
+    page.theme = 'Faith in Difficult Times';
+    page.length = 10;
+    await page.generate();
+    expect(ai.generateOutline).toHaveBeenCalledWith({ theme: 'Faith in Difficult Times', length: 10 });
+    expect(page.generated).toBe('Outline');
+  });
+
+  it('saves a customized sermon to storage', () => {
+    storage.get.mockReturnValue([]);
+    const content = 'My Sermon';
+    page.theme = 'Test Theme';
+    page.save(content);
+    expect(storage.get).toHaveBeenCalledWith('sermons');
+    expect(storage.set).toHaveBeenCalled();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- add `jest` based test for CreateSermonPage
- add Jest configuration and TypeScript config
- update test script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ab71915c8327a7439dfdfb70cbbe