### PR TITLE
Implement register and profile features

### DIFF
--- a/core/services/auth.service.ts
+++ b/core/services/auth.service.ts
@@ -7,6 +7,7 @@ export interface AuthResponse {
 
 export class AuthService {
   private tokenKey = 'auth_token';
+  private userKey = 'auth_user';
 
   /**
    * Attempt to log in with the provided credentials.
@@ -23,6 +24,9 @@ export class AuthService {
     }
     const data: AuthResponse = await resp.json();
     localStorage.setItem(this.tokenKey, data.token);
+    try {
+      localStorage.setItem(this.userKey, JSON.stringify(data.user));
+    } catch {}
     return data;
   }
 
@@ -40,17 +44,33 @@ export class AuthService {
     }
     const data: AuthResponse = await resp.json();
     localStorage.setItem(this.tokenKey, data.token);
+    try {
+      localStorage.setItem(this.userKey, JSON.stringify(data.user));
+    } catch {}
     return data;
   }
 
   /** Remove saved auth token. */
   logout() {
     localStorage.removeItem(this.tokenKey);
+    localStorage.removeItem(this.userKey);
   }
 
   /** Return the saved auth token if present. */
   get token(): string | null {
     return localStorage.getItem(this.tokenKey);
+  }
+
+  get user(): { id: string; email: string } | null {
+    const data = localStorage.getItem(this.userKey);
+    if (!data) {
+      return null;
+    }
+    try {
+      return JSON.parse(data) as { id: string; email: string };
+    } catch {
+      return null;
+    }
   }
 
   /** Whether a valid auth token is stored. */

--- a/features/auth/login.page.ts
+++ b/features/auth/login.page.ts
@@ -21,7 +21,10 @@ export class LoginPage {
 
   async login() {
     try {
-      await this.auth.login(this.email, this.password);
+      const resp = await this.auth.login(this.email, this.password);
+      try {
+        localStorage.setItem('auth_user', JSON.stringify(resp.user));
+      } catch {}
       this.error = '';
       this.loggedIn.emit();
     } catch {

--- a/features/auth/profile.page.ts
+++ b/features/auth/profile.page.ts
@@ -1,2 +1,40 @@
-export class ProfilePage extends HTMLElement {}
-customElements.define('profile-page', ProfilePage);
+import { Component, EventEmitter, Output } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule } from '@angular/common';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  selector: 'app-profile',
+  standalone: true,
+  imports: [IonicModule, CommonModule],
+  template: `
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Profile</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content class="ion-padding">
+      <ng-container *ngIf="user; else loggedOut">
+        <p>Email: {{ user?.email }}</p>
+        <ion-button expand="full" (click)="logout()">Logout</ion-button>
+      </ng-container>
+      <ng-template #loggedOut>
+        <p>You are not logged in.</p>
+      </ng-template>
+    </ion-content>
+  `
+})
+export class ProfilePage {
+  @Output() loggedOut = new EventEmitter<void>();
+
+  constructor(private auth: AuthService) {}
+
+  get user() {
+    return this.auth.user;
+  }
+
+  logout() {
+    this.auth.logout();
+    this.loggedOut.emit();
+  }
+}

--- a/features/auth/register.page.css
+++ b/features/auth/register.page.css
@@ -1,0 +1,3 @@
+.error {
+  color: red;
+}

--- a/features/auth/register.page.html
+++ b/features/auth/register.page.html
@@ -1,0 +1,19 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Register</ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content class="ion-padding">
+  <form (ngSubmit)="register()" #form="ngForm">
+    <ion-item>
+      <ion-label position="stacked">Email</ion-label>
+      <ion-input type="email" name="email" required [(ngModel)]="email"></ion-input>
+    </ion-item>
+    <ion-item>
+      <ion-label position="stacked">Password</ion-label>
+      <ion-input type="password" name="password" required [(ngModel)]="password"></ion-input>
+    </ion-item>
+    <ion-button expand="full" type="submit" [disabled]="form.invalid">Register</ion-button>
+  </form>
+  <div class="error" *ngIf="error">{{ error }}</div>
+</ion-content>

--- a/features/auth/register.page.ts
+++ b/features/auth/register.page.ts
@@ -1,2 +1,34 @@
-export class RegisterPage extends HTMLElement {}
-customElements.define('register-page', RegisterPage);
+import { Component, EventEmitter, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [IonicModule, FormsModule],
+  templateUrl: './register.page.html',
+  styleUrls: ['./register.page.css']
+})
+export class RegisterPage {
+  email = '';
+  password = '';
+  error = '';
+
+  @Output() registered = new EventEmitter<void>();
+
+  constructor(private auth: AuthService) {}
+
+  async register() {
+    try {
+      const resp = await this.auth.register(this.email, this.password);
+      try {
+        localStorage.setItem('auth_user', JSON.stringify(resp.user));
+      } catch {}
+      this.error = '';
+      this.registered.emit();
+    } catch {
+      this.error = 'Registration failed';
+    }
+  }
+}

--- a/tests/profile.page.spec.ts
+++ b/tests/profile.page.spec.ts
@@ -1,0 +1,24 @@
+import { ProfilePage } from '../features/auth/profile.page';
+import { AuthService } from '../core/services/auth.service';
+
+describe('ProfilePage', () => {
+  let auth: jest.Mocked<AuthService>;
+  let page: ProfilePage;
+
+  beforeEach(() => {
+    auth = { user: { id: '1', email: 'e@test.com' }, logout: jest.fn() } as any;
+    page = new ProfilePage(auth);
+  });
+
+  it('exposes user from auth service', () => {
+    expect(page.user).toEqual({ id: '1', email: 'e@test.com' });
+  });
+
+  it('logs out and emits event', () => {
+    const emitted: number[] = [];
+    page.loggedOut.subscribe(() => emitted.push(1));
+    page.logout();
+    expect(auth.logout).toHaveBeenCalled();
+    expect(emitted.length).toBe(1);
+  });
+});

--- a/tests/register.page.spec.ts
+++ b/tests/register.page.spec.ts
@@ -1,0 +1,32 @@
+import { RegisterPage } from '../features/auth/register.page';
+import { AuthService } from '../core/services/auth.service';
+
+describe('RegisterPage', () => {
+  let auth: jest.Mocked<AuthService>;
+  let page: RegisterPage;
+
+  beforeEach(() => {
+    auth = { register: jest.fn() } as any;
+    page = new RegisterPage(auth);
+    localStorage.clear();
+  });
+
+  it('registers and emits event on success', async () => {
+    auth.register.mockResolvedValue({ token: 't', user: { id: '1', email: 'e@test.com' } });
+    page.email = 'e@test.com';
+    page.password = 'p';
+    const emitted: number[] = [];
+    page.registered.subscribe(() => emitted.push(1));
+    await page.register();
+    expect(auth.register).toHaveBeenCalledWith('e@test.com', 'p');
+    expect(localStorage.getItem('auth_user')).toBe(JSON.stringify({ id: '1', email: 'e@test.com' }));
+    expect(emitted.length).toBe(1);
+    expect(page.error).toBe('');
+  });
+
+  it('sets error message on failure', async () => {
+    auth.register.mockRejectedValue(new Error('fail'));
+    await page.register();
+    expect(page.error).toBe('Registration failed');
+  });
+});


### PR DESCRIPTION
## Summary
- implement user storage and retrieval in `AuthService`
- store user info on login
- add register page with simple form
- add profile page with logout button
- add unit tests for new pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b223bde08327b04aff47464d3868